### PR TITLE
Fix Denmark scraper tries to call text method on nil

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -74,7 +74,9 @@ end
   page.css('h2 + ul').each do |initial|
     break if initial.xpath('preceding::h2').last.text.include? 'Eksterne henvisninger'
     initial.css('li').each do |mem|
-      next if mem.attr('class') == 'mw-empty-li'
+      next if mem.attr('class') == 'mw-empty-li' || mem.attr('class') == 'mw-empty-elt'
+      require 'pry'
+      binding.pry if mem.at_xpath('.//a').nil?
       data = { 
         name: mem.at_xpath('.//a').text.strip,
         party_id: (mem.at_xpath('./text()').text.strip)[/\((.*?)\)/, 1],

--- a/scraper.rb
+++ b/scraper.rb
@@ -75,8 +75,6 @@ end
     break if initial.xpath('preceding::h2').last.text.include? 'Eksterne henvisninger'
     initial.css('li').each do |mem|
       next if mem.attr('class') == 'mw-empty-li' || mem.attr('class') == 'mw-empty-elt'
-      require 'pry'
-      binding.pry if mem.at_xpath('.//a').nil?
       data = { 
         name: mem.at_xpath('.//a').text.strip,
         party_id: (mem.at_xpath('./text()').text.strip)[/\((.*?)\)/, 1],


### PR DESCRIPTION
Denmark scraper failing. Morph output:

```
scraper.rb:79:in `block (3 levels) in <main>': undefined method `text' for nil:NilClass (NoMethodError)
```

Skips element if class is `mw-empty-elt`

Fixes everypolitician/everypolitician-data/issues/14879
